### PR TITLE
Fix: Prevent Page Scroll on Chat Window Toggle

### DIFF
--- a/src/chatWidget/chatTrigger/index.tsx
+++ b/src/chatWidget/chatTrigger/index.tsx
@@ -3,7 +3,10 @@ export default function ChatTrigger({ style, open, setOpen, triggerRef }: { styl
 
     return (
         <button ref={triggerRef} style={style}
-            onClick={() => { setOpen(!open)}}
+            onClick={() => { setOpen(!open) }}
+            onMouseDown={(e) => {
+                e.preventDefault()
+            }}
             className="cl-trigger">
             <X className={"cl-trigger-icon " + (open ? "cl-scale-100" : "cl-scale-0")} />
             <MessageSquare className={"cl-trigger-icon " + (open ? "cl-scale-0" : "cl-scale-100")} />


### PR DESCRIPTION
This PR addresses an issue where clicking the chat trigger button to close the chat window causes the page to scroll to the end when the chat window is larger than the page.